### PR TITLE
feat: only return ids with 22 characters

### DIFF
--- a/src/id.test.ts
+++ b/src/id.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from 'vitest';
+
+import { BASE58_ALLOWED_CHARS } from './core/base58.js';
+import { make } from './id.js';
+
+it('should generate valid base58 encoded id with length of 22', () => {
+  const id = make();
+  expect(id).toBeTypeOf('string');
+  expect(id.length).toBe(22);
+  expect(id.split('').every(char => BASE58_ALLOWED_CHARS.includes(char))).toBe(true);
+});

--- a/src/id.ts
+++ b/src/id.ts
@@ -18,5 +18,16 @@ import { encodeBase58 } from './core/base58.js';
 export function make() {
   const uuid = uuidv4();
   const stripped = uuid.replaceAll(/-/g, '');
-  return encodeBase58(stripped);
+  const id = encodeBase58(stripped);
+
+  // In extremely rare occasions the id generator may result in ids that are
+  // 21 characters instead of 22. Theoretically the smallest length the id can
+  // generate is 16 characters, but only in specifically engineered cases.
+  //
+  // If this occurs we can generate again until we get a valid id.
+  if (id.length === 22) {
+    return id;
+  }
+
+  return make();
 }


### PR DESCRIPTION
In extremely rare occasions the id generator may result in ids that are 21 characters instead of 22. Theoretically the smallest length the id can generate is 16 characters, but only in specifically engineered cases.

If this occurs we can generate again until we get a valid id.

Note that ids that aren't 22 character won't break anything in the system. This change is moreso to standardize 22 character ids as much as possible.