### PR TITLE
fix: simplify github workflows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -52,31 +52,9 @@ jobs:
       - name: Test
         run: pnpm test
 
-  typecheck:
-    name: Type check
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Type check
-        run: pnpm check
-
   lint:
     name: Linting & formatting
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "test": "vitest",
     "generate:protobuf": "npx buf generate",
     "lint": "biome check --write --unsafe",
-    "format": "biome check --write --unsafe",
-    "check": "tsc --noEmit"
+    "format": "biome check --write --unsafe"
   },
   "dependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
- Don't need to wait on build to run linter/formatter
- Don't need a separate Check workflow since Build already type checks