### PR TITLE
fix: flaky base58 test

### DIFF
--- a/src/core/base58.test.ts
+++ b/src/core/base58.test.ts
@@ -12,7 +12,7 @@ describe('base58', () => {
 
     // We check the length should be 22 in the ID.make() function and
     // re-run encodeBase58 if not.
-    expect(encoded.length === 22 || encoded.length === 21).toBe(22);
+    expect(encoded.length === 22 || encoded.length === 21).toBe(true);
 
     const decoded = decodeBase58ToUUID(encoded);
     expect(decoded).toHaveLength(expected.length);

--- a/src/core/base58.test.ts
+++ b/src/core/base58.test.ts
@@ -9,7 +9,10 @@ describe('base58', () => {
     const given = expected.replaceAll(/-/g, '');
 
     const encoded = encodeBase58(given);
-    expect(encoded).toHaveLength(22);
+
+    // We check the length should be 22 in the ID.make() function and
+    // re-run encodeBase58 if not.
+    expect(encoded.length === 22 || encoded.length === 21).toBe(22);
 
     const decoded = decodeBase58ToUUID(encoded);
     expect(decoded).toHaveLength(expected.length);

--- a/src/id.test.ts
+++ b/src/id.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from 'vitest';
 import { BASE58_ALLOWED_CHARS } from './core/base58.js';
 import { make } from './id.js';
 
+// @NOTE this would be a good candidate for DST-style tests
 it('should generate valid base58 encoded id with length of 22', () => {
   const id = make();
   expect(id).toBeTypeOf('string');


### PR DESCRIPTION
`encodeBase58` can sometimes return 21 characters instead of 22. We handle this at the `ID.make()` function and re-execute with a new id seed to ensure we end up with 22-length ids.