### PR TITLE
chore: upgrade pnpm to latest version

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,9 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -37,9 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -47,7 +43,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile 
+        run: pnpm install --frozen-lockfile
 
       - name: Test
         run: pnpm test
@@ -57,9 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "@bufbuild/protoc-gen-es": "^1.9.0",
     "typescript": "^5.4.5"
   },
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@10.4.1"
 }


### PR DESCRIPTION
In the CI the version does not need to be defined due:

> Optional when there is a [packageManager field in the package.json](https://nodejs.org/api/corepack.html).

source: https://github.com/pnpm/action-setup?tab=readme-ov-file#version